### PR TITLE
Specify corejs dep to fix warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ module.exports = () => ({
       require("@babel/preset-env").default,
       {
         useBuiltIns: "entry",
-        modules: false
+        modules: false,
+        corejs: 3
       }
     ],
     require("@babel/preset-react").default

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = () => ({
       {
         useBuiltIns: "entry",
         modules: false,
-        corejs: 3
+        corejs: 2
       }
     ],
     require("@babel/preset-react").default

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
-    "babel-plugin-transform-dynamic-import": "^2.1.0",
-    "core-js": "3"
+    "babel-plugin-transform-dynamic-import": "^2.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-codecademy",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "A collection of babel plugins and presets used at codecademy.com",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
-    "babel-plugin-transform-dynamic-import": "^2.1.0"
+    "babel-plugin-transform-dynamic-import": "^2.1.0",
+    "core-js": "3"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,11 +1133,6 @@ core-js-compat@^3.4.7:
     browserslist "^4.8.0"
     semver "^6.3.0"
 
-core-js@3:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
-
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,6 +1133,11 @@ core-js-compat@^3.4.7:
     browserslist "^4.8.0"
     semver "^6.3.0"
 
+core-js@3:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
Tired of seeing this every time you build Gamut?

```
WARNING: We noticed you're using the `useBuiltIns` option without declaring a core-js version. Currently, we assume version 2.x when no version is passed. Since this default version will likely change in future versions of Babel, we recommend explicitly setting the core-js version you are using via the `corejs` option.

You should also be sure that the version you pass to the `corejs` option matches the version specified in your `package.json`'s `dependencies` section. If it doesn't, you need to run one of the following commands:

  npm install --save core-js@2    npm install --save core-js@3
  yarn add core-js@2              yarn add core-js@3

```

Well, no more!