### PR TITLE
Babel runtime version lock

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
+const path = require("path");
+
 const env = process.env.BABEL_ENV || process.env.NODE_ENV;
 const isEnvTest = env === "test";
 const isEnvProduction = env === "production";
 const isEnvDevelopment = !isEnvTest && !isEnvProduction;
+
+const absoluteRuntimePath = path.dirname(
+  require.resolve("@babel/runtime/package.json")
+);
 
 module.exports = () => ({
   presets: [
@@ -52,6 +58,9 @@ module.exports = () => ({
         helpers: true,
         regenerator: true,
         useESModules: isEnvDevelopment || isEnvProduction,
+        // Undocumented: ensures that the correct runtime version is used
+        // https://github.com/babel/babel/blob/090c364a90fe73d36a30707fc612ce037bdbbb24/packages/babel-plugin-transform-runtime/src/index.js#L35-L42
+        absoluteRuntime: absoluteRuntimePath,
       },
     ],
     require("babel-plugin-react-anonymous-display-name").default,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@babel/core": "^7.12.3"
+    "@babel/core": "^7.12.3",
+    "@babel/runtime": "^7.12.1"
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-codecademy",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A collection of babel plugins and presets used at codecademy.com",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Ran into some @babel/runtime version issues because of some older modules that import runtime, this locks the version.

Code is borrowed from the create-react-app babel config: https://github.com/facebook/create-react-app/blob/master/packages/babel-preset-react-app/create.js#L176