### PR TITLE
Add options to enable/disable the previously added changes (helpers & runtime path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,35 @@ $ npm install --save-dev babel-preset-codecademy
 $ babel script.js --presets codecademy
 ```
 
-### Via Node API
+### Options
 
-```javascript
-require('babel-core').transform('code', {
-  presets: ['codecademy']
-});
+#### Type
+
+default: 'library'
+
+Certain options can be turned on and off depending on what you're using babel for.
+
+For applications, we enable runtime helpers and `@babel/runtime` becomes a required dependency.
+
+```json
+{
+  "presets": ["codecademy", { "type": "application" }]
+}
+```
+
+For libraries (default), we don't enable runtime helpers because then the resulting package would need `@babel/runtime` as a dependency, which should be handled by the consumer of the package.
+
+```json
+{
+  "presets": ["codecademy", { "type": "library" }]
+}
 ```
 
 ## Publishing this package
 
 This package is automatically published by GitHub Actions when the version number changes
 
-* merge your PR into `main`
-* create a new PR that updates the version of the package in package.json. Base the version bump on all of the changes that will be added in this version.
-* merge the version PR into `main`
-* check the [actions](https://github.com/Codecademy/babel-preset-codecademy/actions) to see when the package is published
+- merge your PR into `main`
+- create a new PR that updates the version of the package in package.json. Base the version bump on all of the changes that will be added in this version.
+- merge the version PR into `main`
+- check the [actions](https://github.com/Codecademy/babel-preset-codecademy/actions) to see when the package is published

--- a/index.js
+++ b/index.js
@@ -7,21 +7,20 @@ const isEnvDevelopment = !isEnvTest && !isEnvProduction;
 
 const PACKAGE_LIBRARY = "library";
 const PACKAGE_APPLICATION = "application";
+const packageTypes = [PACKAGE_LIBRARY, PACKAGE_APPLICATION];
 
-module.exports = (api, opts) => {
-  const packageType = opts.type || PACKAGE_APPLICATION;
-
-  if (!packageTypes.includes(packageType)) {
+module.exports = (api, { type = PACKAGE_LIBRARY } = {}) => {
+  if (!packageTypes.includes(type)) {
     throw new Error(
       `babel-preset-codecademy: option 'type' should be one of: ${[
         PACKAGE_LIBRARY,
         PACKAGE_APPLICATION,
-      ].join(", ")}, received ${packageType}`
+      ].join(", ")}, received ${type}`
     );
   }
 
   let absoluteRuntimePath = undefined;
-  if (packageType === PACKAGE_APPLICATION) {
+  if (type === PACKAGE_APPLICATION) {
     absoluteRuntimePath = path.dirname(
       require.resolve("@babel/runtime/package.json")
     );

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = (api, { type = PACKAGE_LIBRARY } = {}) => {
     );
   }
 
-  let absoluteRuntimePath = undefined;
+  let absoluteRuntimePath;
   if (type === PACKAGE_APPLICATION) {
     absoluteRuntimePath = path.dirname(
       require.resolve("@babel/runtime/package.json")

--- a/index.js
+++ b/index.js
@@ -5,68 +5,87 @@ const isEnvTest = env === "test";
 const isEnvProduction = env === "production";
 const isEnvDevelopment = !isEnvTest && !isEnvProduction;
 
-const absoluteRuntimePath = path.dirname(
-  require.resolve("@babel/runtime/package.json")
-);
+const PACKAGE_LIBRARY = "library";
+const PACKAGE_APPLICATION = "application";
 
-module.exports = () => ({
-  presets: [
-    isEnvTest && [
-      require("@babel/preset-env").default,
-      {
-        targets: {
-          node: "current",
+module.exports = (api, opts) => {
+  const packageType = opts.type || PACKAGE_APPLICATION;
+
+  if (!packageTypes.includes(packageType)) {
+    throw new Error(
+      `babel-preset-codecademy: option 'type' should be one of: ${[
+        PACKAGE_LIBRARY,
+        PACKAGE_APPLICATION,
+      ].join(", ")}, received ${packageType}`
+    );
+  }
+
+  let absoluteRuntimePath = undefined;
+  if (packageType === PACKAGE_APPLICATION) {
+    absoluteRuntimePath = path.dirname(
+      require.resolve("@babel/runtime/package.json")
+    );
+  }
+
+  return {
+    presets: [
+      isEnvTest && [
+        require("@babel/preset-env").default,
+        {
+          targets: {
+            node: "current",
+          },
         },
-      },
-    ],
-    (isEnvProduction || isEnvDevelopment) && [
-      require("@babel/preset-env").default,
-      {
-        useBuiltIns: "entry",
-        modules: false,
-        corejs: 2,
-      },
-    ],
-    require("@babel/preset-react").default,
-  ].filter(Boolean),
-  plugins: [
-    require("@babel/plugin-transform-destructuring").default,
-    [require("@babel/plugin-proposal-decorators"), { legacy: true }],
-    [
-      require("@babel/plugin-proposal-class-properties").default,
-      {
-        loose: true,
-      },
-    ],
-    [
-      require("@babel/plugin-proposal-object-rest-spread").default,
-      {
-        useBuiltIns: true,
-      },
-    ],
-    require("@babel/plugin-proposal-do-expressions"),
-    require("@babel/plugin-proposal-export-default-from"),
-    require("@babel/plugin-proposal-export-namespace-from"),
-    require("@babel/plugin-proposal-nullish-coalescing-operator"),
-    require("@babel/plugin-proposal-optional-chaining"),
-    require("@babel/plugin-syntax-import-meta"),
-    [
-      require("@babel/plugin-transform-runtime").default,
-      {
-        corejs: false,
-        regenerator: true,
-        helpers: true,
-        regenerator: true,
-        useESModules: isEnvDevelopment || isEnvProduction,
-        // Undocumented: ensures that the correct runtime version is used
-        // https://github.com/babel/babel/blob/090c364a90fe73d36a30707fc612ce037bdbbb24/packages/babel-plugin-transform-runtime/src/index.js#L35-L42
-        absoluteRuntime: absoluteRuntimePath,
-      },
-    ],
-    require("babel-plugin-react-anonymous-display-name").default,
-    require("@babel/plugin-syntax-dynamic-import").default,
-    isEnvTest &&
-      // Transform dynamic import to require
-      require("babel-plugin-transform-dynamic-import").default,
-  ].filter(Boolean),
-});
+      ],
+      (isEnvProduction || isEnvDevelopment) && [
+        require("@babel/preset-env").default,
+        {
+          useBuiltIns: "entry",
+          modules: false,
+          corejs: 2,
+        },
+      ],
+      require("@babel/preset-react").default,
+    ].filter(Boolean),
+    plugins: [
+      require("@babel/plugin-transform-destructuring").default,
+      [require("@babel/plugin-proposal-decorators"), { legacy: true }],
+      [
+        require("@babel/plugin-proposal-class-properties").default,
+        {
+          loose: true,
+        },
+      ],
+      [
+        require("@babel/plugin-proposal-object-rest-spread").default,
+        {
+          useBuiltIns: true,
+        },
+      ],
+      require("@babel/plugin-proposal-do-expressions"),
+      require("@babel/plugin-proposal-export-default-from"),
+      require("@babel/plugin-proposal-export-namespace-from"),
+      require("@babel/plugin-proposal-nullish-coalescing-operator"),
+      require("@babel/plugin-proposal-optional-chaining"),
+      require("@babel/plugin-syntax-import-meta"),
+      [
+        require("@babel/plugin-transform-runtime").default,
+        {
+          corejs: false,
+          regenerator: true,
+          helpers: packageType === PACKAGE_APPLICATION,
+          regenerator: true,
+          useESModules: isEnvDevelopment || isEnvProduction,
+          // Undocumented: ensures that the correct runtime version is used
+          // https://github.com/babel/babel/blob/090c364a90fe73d36a30707fc612ce037bdbbb24/packages/babel-plugin-transform-runtime/src/index.js#L35-L42
+          absoluteRuntime: absoluteRuntimePath,
+        },
+      ],
+      require("babel-plugin-react-anonymous-display-name").default,
+      require("@babel/plugin-syntax-dynamic-import").default,
+      isEnvTest &&
+        // Transform dynamic import to require
+        require("babel-plugin-transform-dynamic-import").default,
+    ].filter(Boolean),
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-codecademy",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "A collection of babel plugins and presets used at codecademy.com",
   "main": "index.js",
   "keywords": [
@@ -34,8 +34,8 @@
     "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
-    "babel-plugin-transform-dynamic-import": "^2.1.0",
-    "babel-plugin-react-anonymous-display-name": "0.0.1"
+    "babel-plugin-react-anonymous-display-name": "0.0.1",
+    "babel-plugin-transform-dynamic-import": "^2.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",


### PR DESCRIPTION
Turns out we don't want these options when we're using babel to build libraries (in gamut, etc) so we should default them to false and only use them when building applications. 